### PR TITLE
fix: add Restricted status

### DIFF
--- a/app/utils/epic.server.ts
+++ b/app/utils/epic.server.ts
@@ -7,7 +7,7 @@ const UserInfoSchema = z.object({
 	purchases: z.array(
 		z.object({
 			id: z.string(),
-			status: z.literal('Valid'),
+			status: z.literal('Valid').or(z.literal('Restricted')),
 			productId: z.string(),
 		}),
 	),


### PR DESCRIPTION
`Restricted` is a valid viewing state for a purchase with the regional caveat

https://app.frontapp.com/open/msg_1q9hh4sn?key=abcBB-cccHE4RQDDwBYmRbyjkpJir68S