### PR TITLE
Search command rich results

### DIFF
--- a/app/bot/commands/search.ts
+++ b/app/bot/commands/search.ts
@@ -22,13 +22,6 @@ const segmentEmoji: Record<string, string> = {
 	resume: '📄',
 	credit: '🙏',
 	testimonial: '💬',
-
-	// Back-compat: older API returned human-readable segments
-	'Blog Posts': '📝',
-	'Chats with Kent Episodes': '💬',
-	Talks: '🗣',
-	'Call Kent Podcast Episodes': '📳',
-	Workshops: '🔧',
 }
 
 function getSegmentEmoji(segment: string) {

--- a/app/bot/commands/search.ts
+++ b/app/bot/commands/search.ts
@@ -261,15 +261,9 @@ export const search: CommandFn = async interaction => {
 		})
 	}
 
-	const didYouMean = results.length
-		? `Did you mean ${listify(results.map(r => r.title), {
-				type: 'disjunction',
-				stringify: JSON.stringify,
-		  })}?`
-		: ''
 	await interaction.reply({
 		ephemeral: true,
-		content: `I couldn't find any results for: "${query}"\n\n${didYouMean}`,
+		content: `I couldn't find any results for: "${query}"`,
 	})
 }
 search.description = `Search Kent's content`

--- a/app/bot/commands/search.ts
+++ b/app/bot/commands/search.ts
@@ -16,8 +16,8 @@ const segmentEmoji: Record<string, string> = {
 	// New machine categories
 	blog: '📝',
 	page: '📄',
-	ck: '💬',
-	cwk: '🔧',
+	cwk: '💬',
+	ck: '📳',
 	talk: '🗣',
 	resume: '📄',
 	credit: '🙏',

--- a/app/bot/commands/search.ts
+++ b/app/bot/commands/search.ts
@@ -1,5 +1,5 @@
 import { invariant } from '~/utils'
-import { getMember, listify } from '../utils/index'
+import { getMember } from '../utils/index'
 import type { AutocompleteFn, CommandFn } from './utils'
 
 type Result = {


### PR DESCRIPTION
Update Discord bot's `/search` command to display richer semantic search results including summaries and images.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-36cb739a-7e90-4a26-95be-1051715b2e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36cb739a-7e90-4a26-95be-1051715b2e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-facing Discord interaction formatting and adds new truncation/validation logic to prevent embed/API errors; low security impact but moderate risk of regressions in response rendering/limits handling.
> 
> **Overview**
> Updates the Discord bot’s `/search` command to return *richer results* from the search API by accepting machine `segment` categories and optional `summary`/`imageUrl` fields.
> 
> Autocomplete suggestions now include segment emojis and truncated summaries, with safer URL shortening when values exceed Discord limits. Command replies switch from plain URL output to Discord embeds: a single result shows title/summary/thumbnail, and multiple results render a top-5 results embed with character-budgeted fields to avoid Discord’s 6000-char embed limit; the “did you mean” no-results suggestion is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50a4ebdb0fb4d4ca1277ad3519e4eac395f105a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added emoji-based categorization for different search result types
  * Introduced help/usage information for the search command
  * Single search results now display with optional summaries and thumbnail images

* **Improvements**
  * Cleaner URL display with intelligent shortening
  * Enhanced formatting for multiple search results
  * Improved messaging when no results are found

<!-- end of auto-generated comment: release notes by coderabbit.ai -->