### PR TITLE
Fix malformed /search autocomplete queries

### DIFF
--- a/app/bot/commands/search-query-normalizer.test.ts
+++ b/app/bot/commands/search-query-normalizer.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { normalizeSearchCommandQuery } from './search-query-normalizer'
+
+test('normalizeSearchCommandQuery preserves free-typed queries', () => {
+	assert.deepEqual(normalizeSearchCommandQuery('react testing library'), {
+		type: 'search',
+		value: 'react testing library',
+	})
+})
+
+test('normalizeSearchCommandQuery preserves direct URLs', () => {
+	assert.deepEqual(
+		normalizeSearchCommandQuery(
+			'https://kentcdodds.com/blog/testing-implementation-details',
+		),
+		{
+			type: 'url',
+			value: 'https://kentcdodds.com/blog/testing-implementation-details',
+		},
+	)
+})
+
+test('normalizeSearchCommandQuery strips autocomplete labels down to the title', () => {
+	assert.deepEqual(
+		normalizeSearchCommandQuery(
+			'📳 Question about testing alongside RTL - Title: Question about testing alongside RTL Type: ck UR...',
+		),
+		{
+			type: 'search',
+			value: 'Question about testing alongside RTL',
+		},
+	)
+})
+
+test('normalizeSearchCommandQuery extracts embedded URLs from autocomplete labels', () => {
+	assert.deepEqual(
+		normalizeSearchCommandQuery(
+			'📺 Testing implementation details - Watch this: https://kentcdodds.com/youtube/testing-implementation-details',
+		),
+		{
+			type: 'url',
+			value: 'https://kentcdodds.com/youtube/testing-implementation-details',
+		},
+	)
+})
+
+test('normalizeSearchCommandQuery uses metadata titles when only metadata is provided', () => {
+	assert.deepEqual(
+		normalizeSearchCommandQuery(
+			'Title: Question about testing alongside RTL Type: ck',
+		),
+		{
+			type: 'search',
+			value: 'Question about testing alongside RTL',
+		},
+	)
+})

--- a/app/bot/commands/search-query-normalizer.ts
+++ b/app/bot/commands/search-query-normalizer.ts
@@ -11,9 +11,13 @@ function collapseWhitespace(text: string) {
 	return text.replace(/\s+/g, ' ').trim()
 }
 
-function getURL(maybeUrl: string) {
+function getWebUrl(maybeUrl: string) {
+	if (/\s/.test(maybeUrl)) return null
+
 	try {
-		return new URL(maybeUrl)
+		const url = new URL(maybeUrl)
+		if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+		return url
 	} catch (error) {
 		// must not be a valid URL
 		return null
@@ -24,7 +28,7 @@ function getEmbeddedUrl(text: string) {
 	const match = text.match(embeddedUrlPattern)
 	if (!match) return null
 
-	const embeddedUrl = getURL(match[0])
+	const embeddedUrl = getWebUrl(match[0])
 	return embeddedUrl ? embeddedUrl.toString() : null
 }
 
@@ -32,7 +36,7 @@ export function normalizeSearchCommandQuery(
 	rawQuery: string,
 ): SearchCommandQuery {
 	const trimmedQuery = collapseWhitespace(rawQuery)
-	const directUrl = getURL(trimmedQuery)
+	const directUrl = getWebUrl(trimmedQuery)
 	if (directUrl) {
 		return { type: 'url', value: directUrl.toString() }
 	}

--- a/app/bot/commands/search-query-normalizer.ts
+++ b/app/bot/commands/search-query-normalizer.ts
@@ -1,0 +1,59 @@
+export type SearchCommandQuery =
+	| { type: 'url'; value: string }
+	| { type: 'search'; value: string }
+
+const autocompleteSummaryDelimiter = ' - '
+const embeddedUrlPattern = /https?:\/\/\S+/iu
+const leadingEmojiPattern = /^\p{Extended_Pictographic}\uFE0F?\s+/u
+const metadataTitlePattern = /^Title:\s*(.+?)(?=\s+(?:Type|URL):|$)/iu
+
+function collapseWhitespace(text: string) {
+	return text.replace(/\s+/g, ' ').trim()
+}
+
+function getURL(maybeUrl: string) {
+	try {
+		return new URL(maybeUrl)
+	} catch (error) {
+		// must not be a valid URL
+		return null
+	}
+}
+
+function getEmbeddedUrl(text: string) {
+	const match = text.match(embeddedUrlPattern)
+	if (!match) return null
+
+	const embeddedUrl = getURL(match[0])
+	return embeddedUrl ? embeddedUrl.toString() : null
+}
+
+export function normalizeSearchCommandQuery(
+	rawQuery: string,
+): SearchCommandQuery {
+	const trimmedQuery = collapseWhitespace(rawQuery)
+	const directUrl = getURL(trimmedQuery)
+	if (directUrl) {
+		return { type: 'url', value: directUrl.toString() }
+	}
+
+	const embeddedUrl = getEmbeddedUrl(trimmedQuery)
+	if (embeddedUrl) {
+		return { type: 'url', value: embeddedUrl }
+	}
+
+	let normalizedQuery = trimmedQuery.replace(leadingEmojiPattern, '')
+	if (normalizedQuery.includes(autocompleteSummaryDelimiter)) {
+		normalizedQuery =
+			normalizedQuery.split(autocompleteSummaryDelimiter, 1)[0] ??
+			normalizedQuery
+	} else {
+		const titleMatch = normalizedQuery.match(metadataTitlePattern)
+		if (titleMatch?.[1]) normalizedQuery = titleMatch[1]
+	}
+
+	normalizedQuery = collapseWhitespace(normalizedQuery)
+	if (!normalizedQuery) normalizedQuery = trimmedQuery
+
+	return { type: 'search', value: normalizedQuery }
+}

--- a/app/bot/commands/search.ts
+++ b/app/bot/commands/search.ts
@@ -1,5 +1,6 @@
 import { invariant } from '~/utils'
 import { getMember } from '../utils/index'
+import { normalizeSearchCommandQuery } from './search-query-normalizer'
 import { searchAPI } from './search-worker-client'
 import type { AutocompleteFn, CommandFn } from './utils'
 
@@ -114,18 +115,19 @@ export const search: CommandFn = async interaction => {
 	const { guild } = interaction
 	invariant(guild, 'guild is required')
 
-	const query = interaction.options.get('query')?.value
-	invariant(typeof query === 'string', 'query must be a string')
+	const rawQuery = interaction.options.get('query')?.value
+	invariant(typeof rawQuery === 'string', 'query must be a string')
 
 	const toUser = interaction.options.getUser('user')
 	const toMember = toUser ? getMember(guild, toUser.id) : null
 	const toMessage = toMember ? toMember.toString() : ''
 
-	const url = getURL(query)
-	if (url) {
-		return interaction.reply(`${toMessage} ${url}`.trim())
+	const normalizedQuery = normalizeSearchCommandQuery(rawQuery)
+	if (normalizedQuery.type === 'url') {
+		return interaction.reply(`${toMessage} ${normalizedQuery.value}`.trim())
 	}
 
+	const query = normalizedQuery.value
 	const searchResponse = await searchAPI(query, { topK: searchResultLimit })
 	if (searchResponse.type === 'error') {
 		return interaction.reply({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- normalize `/search` inputs before calling the search worker
- recover from malformed autocomplete labels by extracting a URL or falling back to a safe title query
- add regression tests for autocomplete label normalization

## Testing
- `./node_modules/.bin/tsx --test app/bot/commands/search-query-normalizer.test.ts app/bot/commands/search-worker-client.test.ts`
- `./node_modules/.bin/eslint app/bot/commands/search.ts app/bot/commands/search-query-normalizer.ts app/bot/commands/search-query-normalizer.test.ts`
- `./node_modules/.bin/tsc -b`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-288b149c-8269-4e1d-bca2-f5a75141e743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-288b149c-8269-4e1d-bca2-f5a75141e743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

