### PR TITLE
Return selected URLs from search autocomplete

### DIFF
--- a/app/bot/commands/search.test.ts
+++ b/app/bot/commands/search.test.ts
@@ -32,10 +32,11 @@ function parseSearchRequestBody(init: RequestInit | undefined) {
 	return JSON.parse(String(init?.body)) as { query: string; topK: number }
 }
 
-function createInteraction(query: string) {
+function createInteraction(query: string, userId = 'user-1') {
 	const replies: Array<unknown> = []
 	const interaction = {
 		guild: {},
+		user: { id: userId },
 		options: {
 			get(name: string) {
 				if (name === 'query') return { value: query }
@@ -57,10 +58,11 @@ function createInteraction(query: string) {
 	}
 }
 
-function createAutocompleteInteraction(query: string) {
+function createAutocompleteInteraction(query: string, userId = 'user-1') {
 	const responses: Array<unknown> = []
 	const interaction = {
 		guild: {},
+		user: { id: userId },
 		options: {
 			getFocused(required: true) {
 				void required
@@ -84,7 +86,7 @@ test.afterEach(() => {
 	restoreSearchWorkerEnv()
 })
 
-test('search autocomplete keeps the raw user text as the submitted value', async () => {
+test('search autocomplete returns per-result selection tokens', async () => {
 	setSearchWorkerEnv()
 	const query = 'react-testing-library'
 	const capturedBodies: Array<{ query: string; topK: number }> = []
@@ -116,17 +118,62 @@ test('search autocomplete keeps the raw user text as the submitted value', async
 	await autocompleteSearch(interaction)
 
 	assert.deepEqual(capturedBodies, [{ query, topK: 20 }])
-	assert.deepEqual(responses, [
+	assert.equal(responses.length, 1)
+	const [choices] = responses as [
+		Array<{ name: string; value: string }>,
+	]
+	assert.deepEqual(
+		choices.map(choice => choice.name),
 		[
-			{
-				name: '📝 React Testing Library Setup - Learn the setup.',
-				value: query,
-			},
-			{
-				name: '📺 React Testing Library Video - Watch the walkthrough.',
-				value: query,
-			},
+			'📝 React Testing Library Setup - Learn the setup.',
+			'📺 React Testing Library Video - Watch the walkthrough.',
 		],
+	)
+	assert.equal(choices.length, 2)
+	assert.match(choices[0]!.value, /^search-selection:user-1:/)
+	assert.match(choices[1]!.value, /^search-selection:user-1:/)
+	assert.notEqual(choices[0]!.value, choices[1]!.value)
+})
+
+test('search returns the selected autocomplete result URL without rerunning search', async () => {
+	setSearchWorkerEnv()
+	let fetchCallCount = 0
+	global.fetch = (async (_input, init) => {
+		fetchCallCount += 1
+		assert.deepEqual(parseSearchRequestBody(init), {
+			query: 'react-testing-library',
+			topK: 20,
+		})
+		return new Response(
+			JSON.stringify({
+				ok: true,
+				results: [
+					{
+						type: 'blog',
+						title: 'React Testing Library Setup',
+						url: 'https://kentcdodds.com/blog/react-testing-library-setup',
+						snippet: 'Learn the setup.',
+					},
+				],
+			}),
+			{ status: 200, headers: { 'Content-Type': 'application/json' } },
+		)
+	}) as typeof fetch
+
+	const autocomplete = createAutocompleteInteraction('react-testing-library')
+	await autocompleteSearch(autocomplete.interaction)
+
+	const selectionToken = (
+		autocomplete.responses[0] as Array<{ name: string; value: string }>
+	)[0]!.value
+	const { interaction, replies } = createInteraction(selectionToken)
+	await search(interaction)
+
+	assert.equal(fetchCallCount, 1)
+	assert.deepEqual(replies, [
+		{
+			content: 'https://kentcdodds.com/blog/react-testing-library-setup',
+		},
 	])
 })
 

--- a/app/bot/commands/search.ts
+++ b/app/bot/commands/search.ts
@@ -147,7 +147,7 @@ export const search: CommandFn = async interaction => {
 	const toMember = toUser ? getMember(guild, toUser.id) : null
 	const toMessage = toMember ? toMember.toString() : ''
 
-	if (query.startsWith(searchSelectionPrefix)) {
+	if (query.startsWith(`${searchSelectionPrefix}${interaction.user.id}:`)) {
 		const selectedUrl = consumeSearchSelectionToken(query, interaction.user.id)
 		if (!selectedUrl) {
 			return interaction.reply({

--- a/app/bot/commands/search.ts
+++ b/app/bot/commands/search.ts
@@ -32,6 +32,15 @@ const discordEmbedLimits = {
 } as const
 
 const searchResultLimit = 20 as const
+const searchSelectionPrefix = 'search-selection:'
+const searchSelectionTtlMs = 5 * 60 * 1000
+
+const searchSelectionCache = new Map<
+	string,
+	{ userId: string; url: string; expiresAt: number }
+>()
+
+let searchSelectionSequence = 0
 
 function truncate(text: string, maxLength: number) {
 	if (text.length <= maxLength) return text
@@ -49,6 +58,39 @@ function getSafeHttpUrl(maybeUrl: string | undefined) {
 	if (!url) return undefined
 	if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined
 	return url.toString()
+}
+
+function pruneExpiredSearchSelections(now = Date.now()) {
+	for (const [token, entry] of searchSelectionCache) {
+		if (entry.expiresAt <= now) {
+			searchSelectionCache.delete(token)
+		}
+	}
+}
+
+function createSearchSelectionToken(userId: string, url: string) {
+	const now = Date.now()
+	pruneExpiredSearchSelections(now)
+
+	const token = `${searchSelectionPrefix}${userId}:${now.toString(36)}:${searchSelectionSequence.toString(36)}`
+	searchSelectionSequence += 1
+	searchSelectionCache.set(token, {
+		userId,
+		url,
+		expiresAt: now + searchSelectionTtlMs,
+	})
+
+	return token
+}
+
+function consumeSearchSelectionToken(token: string, userId: string) {
+	pruneExpiredSearchSelections()
+
+	const entry = searchSelectionCache.get(token)
+	if (!entry || entry.userId !== userId) return null
+
+	searchSelectionCache.delete(token)
+	return entry.url
 }
 
 export const autocompleteSearch: AutocompleteFn = async interaction => {
@@ -79,7 +121,7 @@ export const autocompleteSearch: AutocompleteFn = async interaction => {
 					: baseName
 			return {
 				name: truncate(withSummary, 100),
-				value: queryValue,
+				value: createSearchSelectionToken(interaction.user.id, result.url),
 			}
 		}),
 	)
@@ -104,6 +146,20 @@ export const search: CommandFn = async interaction => {
 	const toUser = interaction.options.getUser('user')
 	const toMember = toUser ? getMember(guild, toUser.id) : null
 	const toMessage = toMember ? toMember.toString() : ''
+
+	if (query.startsWith(searchSelectionPrefix)) {
+		const selectedUrl = consumeSearchSelectionToken(query, interaction.user.id)
+		if (!selectedUrl) {
+			return interaction.reply({
+				ephemeral: true,
+				content: 'That search selection expired. Please run /search again.',
+			})
+		}
+
+		return interaction.reply({
+			content: [toMessage, selectedUrl].filter(Boolean).join(' '),
+		})
+	}
 
 	const searchResponse = await searchAPI(query, { topK: searchResultLimit })
 	if (searchResponse.type === 'error') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- cache search autocomplete selections per user and submit a short selection token instead of the raw query text
- resolve selected tokens directly to the chosen result URL when `/search` runs, with an expired-selection fallback message
- add tests covering tokenized autocomplete values and the direct URL response flow

## Testing
- `node --test --import tsx ./app/bot/commands/search.test.ts ./app/bot/commands/search-worker-client.test.ts`
- `npm run typecheck`
- `npm run lint -- app/bot/commands/search.ts app/bot/commands/search.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02158700-21e6-402e-b405-107537bd4f64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02158700-21e6-402e-b405-107537bd4f64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can pick search results via autocomplete; selections return a short-lived, single-use token that can be redeemed with the search command to insert the chosen URL.
  * Tokens expire and are scoped per user to prevent reuse or cross-user access.

* **Tests**
  * Expanded tests for selection flow, token expiration, single-use semantics, and user-scoped behavior; added assertions for autocomplete choice names and distinct token values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->