### PR TITLE
Normalize search result URLs

### DIFF
--- a/app/bot/commands/search-worker-client.test.ts
+++ b/app/bot/commands/search-worker-client.test.ts
@@ -129,12 +129,16 @@ test('searchAPI expands pathname results into full Kent URLs', async () => {
 				title: 'Relative search result',
 				url: 'https://kentcdodds.com/blog/relative-search-result',
 				summary: 'Returned by the worker as a pathname.',
+				imageUrl: undefined,
+				imageAlt: undefined,
 			},
 			{
 				segment: 'page',
 				title: 'Pathname-only search result',
 				url: 'https://kentcdodds.com/about',
 				summary: 'Returned by the worker without a full URL.',
+				imageUrl: undefined,
+				imageAlt: undefined,
 			},
 		],
 	})

--- a/app/bot/commands/search-worker-client.test.ts
+++ b/app/bot/commands/search-worker-client.test.ts
@@ -94,6 +94,52 @@ test('searchAPI sends authenticated POST requests and normalizes results', async
 	assert.equal(headers.get('content-type'), 'application/json')
 })
 
+test('searchAPI expands pathname results into full Kent URLs', async () => {
+	setSearchWorkerEnv()
+
+	global.fetch = (async () =>
+		new Response(
+			JSON.stringify({
+				ok: true,
+				results: [
+					{
+						type: 'blog',
+						title: 'Relative search result',
+						url: '/blog/relative-search-result',
+						snippet: 'Returned by the worker as a pathname.',
+					},
+					{
+						type: 'page',
+						title: 'Pathname-only search result',
+						pathname: '/about',
+						snippet: 'Returned by the worker without a full URL.',
+					},
+				],
+			}),
+			{ status: 200, headers: { 'Content-Type': 'application/json' } },
+		)) as typeof fetch
+
+	const response = await searchAPI('relative links')
+
+	assert.deepEqual(response, {
+		type: 'success',
+		results: [
+			{
+				segment: 'blog',
+				title: 'Relative search result',
+				url: 'https://kentcdodds.com/blog/relative-search-result',
+				summary: 'Returned by the worker as a pathname.',
+			},
+			{
+				segment: 'page',
+				title: 'Pathname-only search result',
+				url: 'https://kentcdodds.com/about',
+				summary: 'Returned by the worker without a full URL.',
+			},
+		],
+	})
+})
+
 test('searchAPI returns worker JSON errors', async () => {
 	setSearchWorkerEnv()
 

--- a/app/bot/commands/search-worker-client.ts
+++ b/app/bot/commands/search-worker-client.ts
@@ -58,6 +58,7 @@ function normalizeSearchResultUrl(record: SearchWorkerResult) {
 	if (!rawUrl) return null
 
 	try {
+		if (rawUrl.startsWith('//')) return null
 		const url = rawUrl.startsWith('/')
 			? new URL(rawUrl, kcdContentOrigin)
 			: new URL(rawUrl)

--- a/app/bot/commands/search-worker-client.ts
+++ b/app/bot/commands/search-worker-client.ts
@@ -21,6 +21,7 @@ type SearchWorkerErrorResponse = {
 	error: string
 }
 
+const kcdContentOrigin = 'https://kentcdodds.com'
 const defaultTopK = 20
 const maxTopK = 20
 const minTopK = 1
@@ -51,10 +52,26 @@ function getOptionalString(
 	return typeof value === 'string' && value.trim() ? value : undefined
 }
 
+function normalizeSearchResultUrl(record: SearchWorkerResult) {
+	const rawUrl =
+		getOptionalString(record, 'url') ?? getOptionalString(record, 'pathname')
+	if (!rawUrl) return null
+
+	try {
+		const url = rawUrl.startsWith('/')
+			? new URL(rawUrl, kcdContentOrigin)
+			: new URL(rawUrl)
+		if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+		return url.toString()
+	} catch {
+		return null
+	}
+}
+
 function normalizeSearchWorkerResult(
 	maybeResult: SearchWorkerResult,
 ): SearchResult | null {
-	const url = getOptionalString(maybeResult, 'url')
+	const url = normalizeSearchResultUrl(maybeResult)
 	const title = getOptionalString(maybeResult, 'title')
 	if (!url || !title) return null
 

--- a/app/bot/commands/search.test.ts
+++ b/app/bot/commands/search.test.ts
@@ -177,6 +177,48 @@ test('search returns the selected autocomplete result URL without rerunning sear
 	])
 })
 
+test('search returns the selected autocomplete result as a full URL when worker returns a pathname', async () => {
+	setSearchWorkerEnv()
+	let fetchCallCount = 0
+	global.fetch = (async (_input, init) => {
+		fetchCallCount += 1
+		assert.deepEqual(parseSearchRequestBody(init), {
+			query: 'relative-search-result',
+			topK: 20,
+		})
+		return new Response(
+			JSON.stringify({
+				ok: true,
+				results: [
+					{
+						type: 'blog',
+						title: 'Relative search result',
+						url: '/blog/relative-search-result',
+						snippet: 'Learn the setup.',
+					},
+				],
+			}),
+			{ status: 200, headers: { 'Content-Type': 'application/json' } },
+		)
+	}) as typeof fetch
+
+	const autocomplete = createAutocompleteInteraction('relative-search-result')
+	await autocompleteSearch(autocomplete.interaction)
+
+	const selectionToken = (
+		autocomplete.responses[0] as Array<{ name: string; value: string }>
+	)[0]!.value
+	const { interaction, replies } = createInteraction(selectionToken)
+	await search(interaction)
+
+	assert.equal(fetchCallCount, 1)
+	assert.deepEqual(replies, [
+		{
+			content: 'https://kentcdodds.com/blog/relative-search-result',
+		},
+	])
+})
+
 test('search forwards raw query text to searchAPI', async () => {
 	setSearchWorkerEnv()
 	const capturedBodies: Array<{ query: string; topK: number }> = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- normalize worker search results so relative `url` values and `pathname` values become full `https://kentcdodds.com/...` URLs
- ensure the `/search` command reuses those normalized absolute URLs when replying with a selected autocomplete result
- add regression tests for pathname-only worker responses in both the client and command flows

## Testing
- `npx tsx --test app/bot/commands/search.test.ts app/bot/commands/search-worker-client.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-093f7556-b8ac-4a9d-bfd8-49612c8d5228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-093f7556-b8ac-4a9d-bfd8-49612c8d5228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search results with relative URLs or pathnames now expand to full site-domain URLs for correct navigation.

* **Tests**
  * Added tests ensuring relative and pathname search results resolve to absolute site URLs and preserve title/summary fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->