### PR TITLE
Upgrade Discord.js to latest stable release

### DIFF
--- a/app/bot/commands/index.ts
+++ b/app/bot/commands/index.ts
@@ -16,7 +16,7 @@ const autocompletes: Record<string, AutocompleteFn> = {
 }
 
 async function help(
-	interaction: Discord.CommandInteraction<Discord.CacheType>,
+	interaction: Discord.ChatInputCommandInteraction<Discord.CacheType>,
 ) {
 	return interaction.reply({
 		ephemeral: true,
@@ -43,7 +43,7 @@ help.description = 'Get help on how to use the bot'
 
 export function setup(client: Discord.Client) {
 	client.on('interactionCreate', async interaction => {
-		if (interaction.isCommand()) {
+		if (interaction.isChatInputCommand()) {
 			const { commandName } = interaction
 
 			const command = commands[commandName]

--- a/app/bot/commands/utils.ts
+++ b/app/bot/commands/utils.ts
@@ -1,10 +1,12 @@
 import type * as Discord from 'discord.js'
 
 export type CommandFn = {
-	(interaction: Discord.CommandInteraction<Discord.CacheType>): Promise<unknown>
+	(
+		interaction: Discord.ChatInputCommandInteraction<Discord.CacheType>,
+	): Promise<unknown>
 	description: string
 	help?: (
-		interaction: Discord.CommandInteraction<Discord.CacheType>,
+		interaction: Discord.ChatInputCommandInteraction<Discord.CacheType>,
 	) => Promise<unknown>
 }
 

--- a/app/bot/reactions/reactions.ts
+++ b/app/bot/reactions/reactions.ts
@@ -368,11 +368,11 @@ async function spamBan(messageReaction: Discord.MessageReaction) {
 	}
 	const botsChannel = getTalkToBotsChannel(guild)
 
-	function log(...args: Parameters<Discord.TextBasedChannel['send']>) {
+	function log(message: string) {
 		if (botsChannel) {
-			return botsChannel.send(...args)
+			return botsChannel.send(message)
 		} else {
-			console.log(...args)
+			console.log(message)
 		}
 	}
 

--- a/app/bot/utils/index.ts
+++ b/app/bot/utils/index.ts
@@ -126,7 +126,7 @@ _Replying to ${msg.author} <${getMessageLink(msg)}>_
 ${reply}
       `.trim(),
 		)
-		if (channel.isTextBased()) {
+		if (channel.isTextBased() && !channel.isDMBased()) {
 			return sendSelfDestructMessage(
 				channel,
 				`Hey ${msg.author}, I sent you a message here: ${getMessageLink(
@@ -146,7 +146,7 @@ const timeToMs = {
 }
 
 export async function sendSelfDestructMessage(
-	channel: Discord.TextBasedChannel,
+	channel: Discord.GuildTextBasedChannel,
 	messageContent: string,
 	{
 		time = 10,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,6 @@
 		"": {
 			"name": "kcd-discord-bot",
 			"dependencies": {
-				"@discordjs/builders": "^1.2.0",
-				"@discordjs/rest": "^1.2.0",
 				"@remix-run/node": "^1.7.2",
 				"@remix-run/react": "^1.7.2",
 				"@remix-run/serve": "^1.7.2",
@@ -19,8 +17,7 @@
 				"cross-env": "^7.0.3",
 				"date-fns": "^2.29.3",
 				"date-fns-tz": "^1.3.7",
-				"discord-api-types": "^0.37.11",
-				"discord.js": "^14.5.0",
+				"discord.js": "^14.25.1",
 				"dotenv": "^16.0.2",
 				"execa": "^8.0.1",
 				"got": "^12.5.1",
@@ -2236,143 +2233,140 @@
 			}
 		},
 		"node_modules/@discordjs/builders": {
-			"version": "1.6.5",
-			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.5.tgz",
-			"integrity": "sha512-SdweyCs/+mHj+PNhGLLle7RrRFX9ZAhzynHahMCLqp5Zeq7np7XC6/mgzHc79QoVlQ1zZtOkTTiJpOZu5V8Ufg==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+			"integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@discordjs/formatters": "^0.3.2",
-				"@discordjs/util": "^1.0.1",
-				"@sapphire/shapeshift": "^3.9.2",
-				"discord-api-types": "0.37.50",
+				"@discordjs/formatters": "^0.6.2",
+				"@discordjs/util": "^1.2.0",
+				"@sapphire/shapeshift": "^4.0.0",
+				"discord-api-types": "^0.38.33",
 				"fast-deep-equal": "^3.1.3",
-				"ts-mixer": "^6.0.3",
-				"tslib": "^2.6.1"
+				"ts-mixer": "^6.0.4",
+				"tslib": "^2.6.3"
 			},
 			"engines": {
 				"node": ">=16.11.0"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
-		},
-		"node_modules/@discordjs/builders/node_modules/discord-api-types": {
-			"version": "0.37.50",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-			"integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
 		},
 		"node_modules/@discordjs/collection": {
 			"version": "1.5.3",
 			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
 			"integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.2.tgz",
-			"integrity": "sha512-lE++JZK8LSSDRM5nLjhuvWhGuKiXqu+JZ/DsOR89DVVia3z9fdCJVcHF2W/1Zxgq0re7kCzmAJlCMMX3tetKpA==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+			"integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"discord-api-types": "0.37.50"
+				"discord-api-types": "^0.38.33"
 			},
 			"engines": {
 				"node": ">=16.11.0"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
-		},
-		"node_modules/@discordjs/formatters/node_modules/discord-api-types": {
-			"version": "0.37.50",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-			"integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.1.tgz",
-			"integrity": "sha512-Ofa9UqT0U45G/eX86cURQnX7gzOJLG2oC28VhIk/G6IliYgQF7jFByBJEykPSHE4MxPhqCleYvmsrtfKh1nYmQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+			"integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@discordjs/collection": "^1.5.1",
-				"@discordjs/util": "^0.3.0",
-				"@sapphire/async-queue": "^1.5.0",
-				"@sapphire/snowflake": "^3.4.2",
-				"discord-api-types": "^0.37.41",
-				"file-type": "^18.3.0",
-				"tslib": "^2.5.0",
-				"undici": "^5.22.0"
+				"@discordjs/collection": "^2.1.1",
+				"@discordjs/util": "^1.1.1",
+				"@sapphire/async-queue": "^1.5.3",
+				"@sapphire/snowflake": "^3.5.3",
+				"@vladfrangu/async_event_emitter": "^2.4.6",
+				"discord-api-types": "^0.38.16",
+				"magic-bytes.js": "^1.10.0",
+				"tslib": "^2.6.3",
+				"undici": "6.21.3"
 			},
 			"engines": {
-				"node": ">=16.9.0"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
-		"node_modules/@discordjs/rest/node_modules/@discordjs/util": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.3.1.tgz",
-			"integrity": "sha512-HxXKYKg7vohx2/OupUN/4Sd02Ev3PBJ5q0gtjdcvXb0ErCva8jNHWfe/v5sU3UKjIB/uxOhc+TDOnhqffj9pRA==",
+		"node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+			"integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=16.9.0"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
 		"node_modules/@discordjs/util": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.1.tgz",
-			"integrity": "sha512-d0N2yCxB8r4bn00/hvFZwM7goDcUhtViC5un4hPj73Ba4yrChLSJD8fy7Ps5jpTLg1fE9n4K0xBLc1y9WGwSsA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+			"integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"discord-api-types": "^0.38.33"
+			},
 			"engines": {
-				"node": ">=16.11.0"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
 		"node_modules/@discordjs/ws": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.1.tgz",
-			"integrity": "sha512-avvAolBqN3yrSvdBPcJ/0j2g42ABzrv3PEL76e3YTp2WYMGH7cuspkjfSyNWaqYl1J+669dlLp+YFMxSVQyS5g==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+			"integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@discordjs/collection": "^1.5.3",
-				"@discordjs/rest": "^2.0.1",
-				"@discordjs/util": "^1.0.1",
-				"@sapphire/async-queue": "^1.5.0",
-				"@types/ws": "^8.5.5",
-				"@vladfrangu/async_event_emitter": "^2.2.2",
-				"discord-api-types": "0.37.50",
-				"tslib": "^2.6.1",
-				"ws": "^8.13.0"
+				"@discordjs/collection": "^2.1.0",
+				"@discordjs/rest": "^2.5.1",
+				"@discordjs/util": "^1.1.0",
+				"@sapphire/async-queue": "^1.5.2",
+				"@types/ws": "^8.5.10",
+				"@vladfrangu/async_event_emitter": "^2.2.4",
+				"discord-api-types": "^0.38.1",
+				"tslib": "^2.6.2",
+				"ws": "^8.17.0"
 			},
 			"engines": {
 				"node": ">=16.11.0"
+			},
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
-		"node_modules/@discordjs/ws/node_modules/@discordjs/rest": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
-			"integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
-			"dependencies": {
-				"@discordjs/collection": "^1.5.3",
-				"@discordjs/util": "^1.0.1",
-				"@sapphire/async-queue": "^1.5.0",
-				"@sapphire/snowflake": "^3.5.1",
-				"@vladfrangu/async_event_emitter": "^2.2.2",
-				"discord-api-types": "0.37.50",
-				"magic-bytes.js": "^1.0.15",
-				"tslib": "^2.6.1",
-				"undici": "5.22.1"
-			},
+		"node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+			"integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=16.11.0"
-			}
-		},
-		"node_modules/@discordjs/ws/node_modules/discord-api-types": {
-			"version": "0.37.50",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-			"integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
-		},
-		"node_modules/@discordjs/ws/node_modules/undici": {
-			"version": "5.22.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-			"integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
-			"dependencies": {
-				"busboy": "^1.6.0"
+				"node": ">=18"
 			},
-			"engines": {
-				"node": ">=14.0"
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
 		"node_modules/@discordjs/ws/node_modules/ws": {
-			"version": "8.14.2",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-			"integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -2872,14 +2866,6 @@
 			"engines": {
 				"node": ">=14.0.0",
 				"npm": ">=6.0.0"
-			}
-		},
-		"node_modules/@fastify/busboy": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-			"integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
-			"engines": {
-				"node": ">=14"
 			}
 		},
 		"node_modules/@gar/promisify": {
@@ -3622,31 +3608,33 @@
 			"dev": true
 		},
 		"node_modules/@sapphire/async-queue": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-			"integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+			"integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
 			}
 		},
 		"node_modules/@sapphire/shapeshift": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz",
-			"integrity": "sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+			"integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"lodash": "^4.17.21"
 			},
 			"engines": {
-				"node": ">=v14.0.0",
-				"npm": ">=7.0.0"
+				"node": ">=v16"
 			}
 		},
 		"node_modules/@sapphire/snowflake": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
-			"integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+			"integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
@@ -3858,11 +3846,6 @@
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
 			}
-		},
-		"node_modules/@tokenizer/token": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
 		},
 		"node_modules/@tootallnate/quickjs-emscripten": {
 			"version": "0.23.0",
@@ -4226,9 +4209,10 @@
 			"dev": true
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.6.tgz",
-			"integrity": "sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -5054,9 +5038,10 @@
 			}
 		},
 		"node_modules/@vladfrangu/async_event_emitter": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
-			"integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==",
+			"version": "2.4.7",
+			"resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+			"integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
@@ -5841,17 +5826,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-		},
-		"node_modules/busboy": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-			"dependencies": {
-				"streamsearch": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=10.16.0"
-			}
 		},
 		"node_modules/bytes": {
 			"version": "3.0.0",
@@ -6910,87 +6884,39 @@
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.37.60",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.60.tgz",
-			"integrity": "sha512-5BELXTsv7becqVHrD81nZrqT4oEyXXWBwbsO/kwDDu6X3u19VV1tYDB5I5vaVAK+c1chcDeheI9zACBLm41LiQ=="
+			"version": "0.38.42",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.42.tgz",
+			"integrity": "sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ==",
+			"license": "MIT",
+			"workspaces": [
+				"scripts/actions/documentation"
+			]
 		},
 		"node_modules/discord.js": {
-			"version": "14.13.0",
-			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.13.0.tgz",
-			"integrity": "sha512-Kufdvg7fpyTEwANGy9x7i4od4yu5c6gVddGi5CKm4Y5a6sF0VBODObI3o0Bh7TGCj0LfNT8Qp8z04wnLFzgnbA==",
+			"version": "14.25.1",
+			"resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+			"integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@discordjs/builders": "^1.6.5",
-				"@discordjs/collection": "^1.5.3",
-				"@discordjs/formatters": "^0.3.2",
-				"@discordjs/rest": "^2.0.1",
-				"@discordjs/util": "^1.0.1",
-				"@discordjs/ws": "^1.0.1",
-				"@sapphire/snowflake": "^3.5.1",
-				"@types/ws": "^8.5.5",
-				"discord-api-types": "0.37.50",
-				"fast-deep-equal": "^3.1.3",
-				"lodash.snakecase": "^4.1.1",
-				"tslib": "^2.6.1",
-				"undici": "5.22.1",
-				"ws": "^8.13.0"
+				"@discordjs/builders": "^1.13.0",
+				"@discordjs/collection": "1.5.3",
+				"@discordjs/formatters": "^0.6.2",
+				"@discordjs/rest": "^2.6.0",
+				"@discordjs/util": "^1.2.0",
+				"@discordjs/ws": "^1.2.3",
+				"@sapphire/snowflake": "3.5.3",
+				"discord-api-types": "^0.38.33",
+				"fast-deep-equal": "3.1.3",
+				"lodash.snakecase": "4.1.1",
+				"magic-bytes.js": "^1.10.0",
+				"tslib": "^2.6.3",
+				"undici": "6.21.3"
 			},
 			"engines": {
-				"node": ">=16.11.0"
-			}
-		},
-		"node_modules/discord.js/node_modules/@discordjs/rest": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.0.1.tgz",
-			"integrity": "sha512-/eWAdDRvwX/rIE2tuQUmKaxmWeHmGealttIzGzlYfI4+a7y9b6ZoMp8BG/jaohs8D8iEnCNYaZiOFLVFLQb8Zg==",
-			"dependencies": {
-				"@discordjs/collection": "^1.5.3",
-				"@discordjs/util": "^1.0.1",
-				"@sapphire/async-queue": "^1.5.0",
-				"@sapphire/snowflake": "^3.5.1",
-				"@vladfrangu/async_event_emitter": "^2.2.2",
-				"discord-api-types": "0.37.50",
-				"magic-bytes.js": "^1.0.15",
-				"tslib": "^2.6.1",
-				"undici": "5.22.1"
+				"node": ">=18"
 			},
-			"engines": {
-				"node": ">=16.11.0"
-			}
-		},
-		"node_modules/discord.js/node_modules/discord-api-types": {
-			"version": "0.37.50",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.50.tgz",
-			"integrity": "sha512-X4CDiMnDbA3s3RaUXWXmgAIbY1uxab3fqe3qwzg5XutR3wjqi7M3IkgQbsIBzpqBN2YWr/Qdv7JrFRqSgb4TFg=="
-		},
-		"node_modules/discord.js/node_modules/undici": {
-			"version": "5.22.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-			"integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
-			"dependencies": {
-				"busboy": "^1.6.0"
-			},
-			"engines": {
-				"node": ">=14.0"
-			}
-		},
-		"node_modules/discord.js/node_modules/ws": {
-			"version": "8.14.2",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-			"integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
+			"funding": {
+				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
 		"node_modules/dlv": {
@@ -8962,22 +8888,6 @@
 				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
-		"node_modules/file-type": {
-			"version": "18.5.0",
-			"resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
-			"integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
-			"dependencies": {
-				"readable-web-to-node-stream": "^3.0.2",
-				"strtok3": "^7.0.0",
-				"token-types": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
-			}
-		},
 		"node_modules/file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -9901,6 +9811,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -11149,9 +11060,10 @@
 			}
 		},
 		"node_modules/magic-bytes.js": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.5.0.tgz",
-			"integrity": "sha512-wJkXvutRbNWcc37tt5j1HyOK1nosspdh3dj6LUYYAvF6JYNqs53IfRvK9oEpcwiDA1NdoIi64yAMfdivPeVAyw=="
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+			"integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+			"license": "MIT"
 		},
 		"node_modules/magic-string": {
 			"version": "0.26.7",
@@ -13449,18 +13361,6 @@
 				"through": "~2.3"
 			}
 		},
-		"node_modules/peek-readable": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-			"integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
 		"node_modules/peek-stream": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
@@ -14228,6 +14128,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -14235,21 +14136,6 @@
 			},
 			"engines": {
 				"node": ">= 6"
-			}
-		},
-		"node_modules/readable-web-to-node-stream": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-			"integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-			"dependencies": {
-				"readable-stream": "^3.6.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/readdirp": {
@@ -15399,14 +15285,6 @@
 			"resolved": "https://registry.npmjs.org/stream-slice/-/stream-slice-0.1.2.tgz",
 			"integrity": "sha512-QzQxpoacatkreL6jsxnVb7X5R/pGw9OUv2qWTYWnmLpg4NdN31snPy/f3TdQE1ZUXaThRvj1Zw4/OGg0ZkaLMA=="
 		},
-		"node_modules/streamsearch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
 		"node_modules/strict-event-emitter": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
@@ -15417,6 +15295,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -15425,6 +15304,7 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -15616,22 +15496,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/strtok3": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-			"integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
-			"dependencies": {
-				"@tokenizer/token": "^0.3.0",
-				"peek-readable": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/style-to-object": {
@@ -16094,22 +15958,6 @@
 				"node": ">=0.6"
 			}
 		},
-		"node_modules/token-types": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-			"integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
-			"dependencies": {
-				"@tokenizer/token": "^0.3.0",
-				"ieee754": "^1.2.1"
-			},
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
 		"node_modules/toml": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
@@ -16151,9 +15999,10 @@
 			"dev": true
 		},
 		"node_modules/ts-mixer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
-			"integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+			"integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+			"license": "MIT"
 		},
 		"node_modules/ts-node": {
 			"version": "10.9.1",
@@ -16219,9 +16068,10 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -16786,14 +16636,12 @@
 			"dev": true
 		},
 		"node_modules/undici": {
-			"version": "5.26.4",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.26.4.tgz",
-			"integrity": "sha512-OG+QOf0fTLtazL9P9X7yqWxQ+Z0395Wk6DSkyTxtaq3wQEjIroVe7Y4asCX/vcCxYpNGMnwz8F0qbRYUoaQVMw==",
-			"dependencies": {
-				"@fastify/busboy": "^2.0.0"
-			},
+			"version": "6.21.3",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+			"integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=14.0"
+				"node": ">=18.17"
 			}
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
@@ -17074,7 +16922,8 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
 		},
 		"node_modules/utils-merge": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,6 @@
 		"/public/build"
 	],
 	"dependencies": {
-		"@discordjs/builders": "^1.2.0",
-		"@discordjs/rest": "^1.2.0",
 		"@remix-run/node": "^1.7.2",
 		"@remix-run/react": "^1.7.2",
 		"@remix-run/serve": "^1.7.2",
@@ -58,8 +56,7 @@
 		"cross-env": "^7.0.3",
 		"date-fns": "^2.29.3",
 		"date-fns-tz": "^1.3.7",
-		"discord-api-types": "^0.37.11",
-		"discord.js": "^14.5.0",
+		"discord.js": "^14.25.1",
 		"dotenv": "^16.0.2",
 		"execa": "^8.0.1",
 		"got": "^12.5.1",

--- a/scripts/deploy-commands.js
+++ b/scripts/deploy-commands.js
@@ -1,7 +1,5 @@
 const path = require('path')
-const { SlashCommandBuilder } = require('@discordjs/builders')
-const { REST } = require('@discordjs/rest')
-const { Routes } = require('discord-api-types/v9')
+const { REST, Routes, SlashCommandBuilder } = require('discord.js')
 const dotenv = require('dotenv')
 
 dotenv.config({ path: path.join(__dirname, '../.env') })
@@ -53,7 +51,7 @@ const commands = [
 		),
 ].map(command => command.toJSON())
 
-const rest = new REST({ version: '9' }).setToken(DISCORD_BOT_TOKEN)
+const rest = new REST({ version: '10' }).setToken(DISCORD_BOT_TOKEN)
 
 rest
 	.put(Routes.applicationGuildCommands(DISCORD_APP_ID, KCD_GUILD_ID), {

--- a/scripts/deploy-emoji.js
+++ b/scripts/deploy-emoji.js
@@ -1,7 +1,6 @@
 const path = require('path')
 const fs = require('fs').promises
-const { REST } = require('@discordjs/rest')
-const { Routes } = require('discord-api-types/v9')
+const { REST, Routes } = require('discord.js')
 const dotenv = require('dotenv')
 
 dotenv.config({ path: path.join(__dirname, '../.env') })
@@ -11,7 +10,7 @@ const { DISCORD_BOT_TOKEN, KCD_GUILD_ID } = process.env
 invariant(DISCORD_BOT_TOKEN, 'DISCORD_BOT_TOKEN is required')
 invariant(KCD_GUILD_ID, 'KCD_GUILD_ID is required')
 
-const rest = new REST({ version: '9' }).setToken(DISCORD_BOT_TOKEN)
+const rest = new REST({ version: '10' }).setToken(DISCORD_BOT_TOKEN)
 
 const here = (...p) => path.join(__dirname, ...p)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- upgrade `discord.js` from `^14.5.0` to `^14.25.1`, which is the current npm `latest` release
- remove direct `@discordjs/builders`, `@discordjs/rest`, and `discord-api-types` dependencies in favor of the main `discord.js` exports, following the official v14 migration guidance
- update the command and emoji deployment scripts from Discord API v9 to v10 and fix stricter Discord interaction/channel typings surfaced by the newer library

## Migration notes
- reviewed the official Discord.js v14 migration guide and recent release metadata before upgrading
- did not move to v15 because npm marks it as a dev prerelease rather than the stable `latest` tag

## Testing
- `npm run validate`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a6c0705-67da-42f8-910c-6cf36179317c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a6c0705-67da-42f8-910c-6cf36179317c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Discord.js dependency to latest version (v14.25.1).
  * Removed unnecessary dependencies and consolidated imports.
  * Updated REST API version from 9 to 10.

* **Bug Fixes**
  * Restricted self-destruct messages to guild text channels only (no longer applies to direct messages).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->