### PR TITLE
Filter recoverable Discord transient Sentry noise (D-1)

### DIFF
--- a/app/bot/index.ts
+++ b/app/bot/index.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node'
 import * as commands from './commands'
 import * as reactions from './reactions'
 import * as admin from './admin'
+import { isTransientDiscordGatewayError } from '~/utils/discord-transient-errors'
 import {
 	botLog,
 	getBuildTimeInfo,
@@ -30,10 +31,22 @@ export async function start() {
 	}))
 
 	client.on('error', error => {
+		// Gateway handshake timeouts / 503s are recovered by discord.js reconnect.
+		if (isTransientDiscordGatewayError(error)) {
+			console.warn('Transient Discord client error (reconnect expected):', error)
+			return
+		}
 		Sentry.captureException(error, { tags: { 'discord.source': 'client' } })
 	})
 
 	client.on('shardError', (error, shardId) => {
+		if (isTransientDiscordGatewayError(error)) {
+			console.warn(
+				`Transient Discord shard error on shard ${shardId} (reconnect expected):`,
+				error,
+			)
+			return
+		}
 		Sentry.withScope(scope => {
 			scope.setTag('discord.source', 'shard')
 			scope.setExtra('shardId', shardId)

--- a/app/routes/resources.forum-feed.ts
+++ b/app/routes/resources.forum-feed.ts
@@ -7,6 +7,7 @@ import { fetchEpicWebGuild } from '~/bot/utils'
 import { LRUCache } from 'lru-cache'
 import type { CacheEntry } from 'cachified'
 import { cachified, lruCacheAdapter } from 'cachified'
+import { isTransientDiscordHttpError } from '~/utils/discord-transient-errors'
 import { invariantResponse } from '../utils.js'
 
 const lru = new LRUCache<string, CacheEntry>({ max: 100 })
@@ -79,13 +80,34 @@ export async function loader({ request }: DataFunctionArgs) {
 		)
 	}
 
-	const threadData = await getThreadData({
-		guild,
-		channel,
-		tagIds: reqUrl.searchParams.getAll('tagId'),
-		forceFresh: reqUrl.searchParams.has('fresh'),
-	})
-	return json({ status: 'success', threadData } as const)
+	try {
+		const threadData = await getThreadData({
+			guild,
+			channel,
+			tagIds: reqUrl.searchParams.getAll('tagId'),
+			forceFresh: reqUrl.searchParams.has('fresh'),
+		})
+		return json({ status: 'success', threadData } as const)
+	} catch (error) {
+		// Discord REST already retries 5xx; when it still 503s, cachified keeps
+		// serving SWR stale data for background refresh failures. A cold/forced
+		// refresh that fails should return a controlled error instead of an
+		// unhandled rejection (KCD-DISCORD-BOT-2S / 2R).
+		if (isTransientDiscordHttpError(error)) {
+			console.warn(
+				'Discord temporarily unavailable while loading forum feed',
+				error,
+			)
+			return json(
+				{
+					status: 'error',
+					error: 'Discord temporarily unavailable',
+				} as const,
+				{ status: 503 },
+			)
+		}
+		throw error
+	}
 }
 
 async function getThreadData({

--- a/app/utils/discord-transient-errors.test.ts
+++ b/app/utils/discord-transient-errors.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+	isTransientDiscordError,
+	isTransientDiscordGatewayError,
+	isTransientDiscordHttpError,
+	shouldDropTransientDiscordSentryEvent,
+} from './discord-transient-errors'
+
+test('isTransientDiscordHttpError matches Discord.js HTTPError 503', () => {
+	assert.equal(
+		isTransientDiscordHttpError({
+			name: 'HTTPError',
+			message: 'Service Unavailable',
+			status: 503,
+		}),
+		true,
+	)
+	assert.equal(
+		isTransientDiscordHttpError({
+			name: 'HTTPError',
+			message: 'Bad Gateway',
+			status: 502,
+		}),
+		true,
+	)
+	assert.equal(
+		isTransientDiscordHttpError({
+			name: 'HTTPError',
+			message: 'Not Found',
+			status: 404,
+		}),
+		false,
+	)
+	assert.equal(
+		isTransientDiscordHttpError(new Error('Service Unavailable')),
+		false,
+	)
+})
+
+test('isTransientDiscordGatewayError matches reconnect handshake noise', () => {
+	assert.equal(
+		isTransientDiscordGatewayError(
+			new Error('Opening handshake has timed out'),
+		),
+		true,
+	)
+	assert.equal(
+		isTransientDiscordGatewayError(
+			new Error('Unexpected server response: 503'),
+		),
+		true,
+	)
+	assert.equal(
+		isTransientDiscordGatewayError(
+			new Error('Unexpected server response: 502'),
+		),
+		true,
+	)
+	assert.equal(
+		isTransientDiscordGatewayError(
+			new Error('Unexpected server response: 401'),
+		),
+		false,
+	)
+	assert.equal(
+		isTransientDiscordGatewayError(new Error('Authentication failed')),
+		false,
+	)
+})
+
+test('shouldDropTransientDiscordSentryEvent uses originalException first', () => {
+	assert.equal(
+		shouldDropTransientDiscordSentryEvent(
+			{},
+			{
+				originalException: {
+					name: 'HTTPError',
+					message: 'Service Unavailable',
+					status: 503,
+				},
+			},
+		),
+		true,
+	)
+	assert.equal(
+		shouldDropTransientDiscordSentryEvent(
+			{},
+			{ originalException: new Error('boom') },
+		),
+		false,
+	)
+})
+
+test('shouldDropTransientDiscordSentryEvent falls back to exception values', () => {
+	assert.equal(
+		shouldDropTransientDiscordSentryEvent({
+			exception: {
+				values: [
+					{ type: 'HTTPError', value: 'Service Unavailable' },
+					{ type: 'Error', value: 'Opening handshake has timed out' },
+				],
+			},
+		}),
+		true,
+	)
+	assert.equal(
+		shouldDropTransientDiscordSentryEvent({
+			exception: {
+				values: [{ type: 'TypeError', value: 'Cannot read properties' }],
+			},
+		}),
+		false,
+	)
+	assert.equal(isTransientDiscordError(new Error('unrelated')), false)
+})

--- a/app/utils/discord-transient-errors.ts
+++ b/app/utils/discord-transient-errors.ts
@@ -1,0 +1,83 @@
+/**
+ * Predicates for expected Discord operational noise on a long-lived bot:
+ * transient REST 503s and gateway reconnect handshake failures.
+ * Discord.js already retries REST 5xx and reconnects the gateway; these
+ * events are not actionable application bugs.
+ */
+
+const TRANSIENT_GATEWAY_MESSAGES = new Set([
+	'Opening handshake has timed out',
+	'Unexpected server response: 502',
+	'Unexpected server response: 503',
+	'Unexpected server response: 520',
+	'Unexpected server response: 521',
+	'Unexpected server response: 522',
+	'Unexpected server response: 524',
+])
+
+export function getErrorMessage(error: unknown): string {
+	if (typeof error === 'string') return error
+	if (error instanceof Error) return error.message
+	return ''
+}
+
+export function isTransientDiscordHttpError(error: unknown): boolean {
+	if (!error || typeof error !== 'object') return false
+	const candidate = error as {
+		name?: unknown
+		message?: unknown
+		status?: unknown
+	}
+	if (candidate.name !== 'HTTPError') return false
+	if (typeof candidate.status === 'number') {
+		return candidate.status === 503 || candidate.status === 502
+	}
+	return (
+		candidate.message === 'Service Unavailable' ||
+		candidate.message === 'Bad Gateway'
+	)
+}
+
+export function isTransientDiscordGatewayError(error: unknown): boolean {
+	return TRANSIENT_GATEWAY_MESSAGES.has(getErrorMessage(error))
+}
+
+export function isTransientDiscordError(error: unknown): boolean {
+	return (
+		isTransientDiscordHttpError(error) || isTransientDiscordGatewayError(error)
+	)
+}
+
+type SentryEventLike = {
+	exception?: {
+		values?: Array<{
+			type?: string | null
+			value?: string | null
+		}>
+	}
+}
+
+/**
+ * Narrow beforeSend drop for Discord transient noise that still reaches Sentry
+ * (e.g. historical onunhandledrejection from cache refresh, or shard errors).
+ */
+export function shouldDropTransientDiscordSentryEvent(
+	event: SentryEventLike,
+	hint?: { originalException?: unknown },
+): boolean {
+	if (hint?.originalException != null) {
+		return isTransientDiscordError(hint.originalException)
+	}
+	const values = event.exception?.values
+	if (!values?.length) return false
+	return values.some(value =>
+		isTransientDiscordError({
+			name: value.type ?? undefined,
+			message: value.value ?? undefined,
+			status:
+				value.type === 'HTTPError' && value.value === 'Service Unavailable'
+					? 503
+					: undefined,
+		}),
+	)
+}

--- a/app/utils/sentry.server.ts
+++ b/app/utils/sentry.server.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/node'
 import { invariant } from '~/utils'
+import { shouldDropTransientDiscordSentryEvent } from './discord-transient-errors'
 
 export async function init() {
 	if (process.env.NODE_ENV === 'production') {
@@ -11,6 +12,18 @@ export async function init() {
 			environment: process.env.NODE_ENV,
 			// Give the transport time to flush before process exit on uncaught errors
 			shutdownTimeout: 5000,
+			// Discord.js reconnects after these; don't page on gateway blips.
+			ignoreErrors: [
+				'Opening handshake has timed out',
+				'Unexpected server response: 503',
+				'Unexpected server response: 502',
+			],
+			beforeSend(event, hint) {
+				if (shouldDropTransientDiscordSentryEvent(event, hint)) {
+					return null
+				}
+				return event
+			},
 			...(commit ? { release: commit } : {}),
 		})
 		Sentry.setContext('fly', {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sentry cleanup track **D-1** for `kcd-discord-bot`: four open issues were recoverable Discord operational noise on a long-lived bot.

### Recovery confirmed before filtering

- **Forum-feed `HTTPError: Service Unavailable` (KCD-DISCORD-BOT-2S / 2R)** — `@discordjs/rest` already retries 5xx (default 3). `cachified` uses a long SWR window, so background refresh failures keep serving stale thread data. Cold/`?fresh` failures were leaking as `onunhandledrejection`; the loader now returns a controlled `503` JSON response instead.
- **Gateway handshake timeout / 503 (KCD-DISCORD-BOT-5R / 5Q)** — captured via our `shardError` handler. `@discordjs/ws` reconnects/resumes after these; they are not sticky outages.

### Changes

- Shared predicates for transient Discord REST/gateway errors + tests
- Forum-feed loader catches transient HTTP 503/502 and returns JSON `503`
- Bot client/shard error handlers skip capturing gateway handshake blips (log only)
- Sentry `ignoreErrors` + narrow `beforeSend` drop for the same family

### Sentry outcomes

| Issue | Outcome | Sentry status |
| --- | --- | --- |
| KCD-DISCORD-BOT-2S | filtered | ignored |
| KCD-DISCORD-BOT-2R | filtered | ignored |
| KCD-DISCORD-BOT-5R | filtered | ignored |
| KCD-DISCORD-BOT-5Q | filtered | ignored |

**Merged + deployed** to Fly via [actions run 30122710682](https://github.com/kentcdodds/kcd-discord-bot/actions/runs/30122710682). `kcd-discord-bot` unresolved count is now **0**.

Risk: **low** — error classification/filtering and a controlled API error response; no auth/payment/data-deletion surface.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4082edc1-123d-4eb0-aea6-c20e6dca1546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4082edc1-123d-4eb0-aea6-c20e6dca1546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

